### PR TITLE
DLC List Edit

### DIFF
--- a/resource/styles/steam.styles
+++ b/resource/styles/steam.styles
@@ -1211,7 +1211,7 @@ steam.styles
 			bgcolor="none"
 			render_bg
 			{
-				0="fill ( x0 + 1, y0 + 3, x1, y1, DialogBGL )"
+				0="fill ( x0, y0 + 3, x1, y1, DialogBGL )"
 			}
 		}
 		


### PR DESCRIPTION
This edits out the 2 extra lines in the column header of the DLC List. I found it odd that they were there since they aren't included in the default Steam skin and seem unnecessary.

Currently, this is how it appears:
![](http://i.imgur.com/GdBYPLw.png)

With the edit, it removes the line before "item" and after "install":
![](http://i.imgur.com/3uboV9j.png)
