### PR TITLE
Keep "Smaller Big Picture icon" override in sync

### DIFF
--- a/Overrides/Smaller Big Picture icon/resource/styles/steam.styles
+++ b/Overrides/Smaller Big Picture icon/resource/styles/steam.styles
@@ -1211,7 +1211,7 @@ steam.styles
 			bgcolor="none"
 			render_bg
 			{
-				0="fill ( x0 + 1, y0 + 3, x1, y1, DialogBGL )"
+				0="fill ( x0, y0 + 3, x1, y1, DialogBGL )"
 			}
 		}
 		


### PR DESCRIPTION
Update override's steam.styles to include fix from https://github.com/somini/Pixelvision2/commit/95afd94d6ef9e4b6426e4ec5450c8bb0fc5abd99
