### PR TITLE
Minor Fixes

### DIFF
--- a/Overrides/Smaller Big Picture icon/resource/layout/uinavigatorpanel.layout
+++ b/Overrides/Smaller Big Picture icon/resource/layout/uinavigatorpanel.layout
@@ -626,21 +626,6 @@
 			{
 				0="fill( x0, y0, x1, y1, almostblack )" // bg
 			}
-
-			render
-			{
-				0="fill( x0 - 1, y0 + 1, x0 + 1, y1    , DialogBG )"// Left
-
-				// Outer Border
-				1="fill( x0 + 1, y1 - 1, x1 - 0, y1    , ScreenB )"	// Bottom
-				2="fill( x0 + 1, y0 + 1, x0 + 2, y1 - 1, ScreenB4 )"// Left
-				3="fill( x1 - 1, y0 + 1, x1    , y1 - 1, ScreenB )"	// Right
-				
-				// Inner Border
-				4="fill( x0 + 2, y1 - 2, x1 - 1, y1 - 1, Black )"	// Bottom
-				5="fill( x0 + 2, y0 + 2, x0 + 3, y1 - 2, Black )"	// Left
-				6="fill( x1 - 2, y0 + 2, x1 - 1, y1 - 2, Black )"	// Right
-			}
 		}
 		
 		TextEntryURL
@@ -890,7 +875,7 @@
 		place { control=GamesPage_Details 	width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }
 		place { control=GamesPage_Grid 		width=max height=max margin-top=1 margin-left=0 margin-right=9 margin-bottom=20 start=emailreminderbar dir=down }
 		place { control=WebPanel 			width=max height=max margin-top=1 margin-left=1 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }
-		place { control=BroadcastPage			width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }
+		place { control=BroadcastPage			width=max height=max margin-top=3 margin-left=3 margin-right=11 margin-bottom=23 start=emailreminderbar dir=down }
 		place { control=BroadcastPageMin		width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=26 dir=down align=bottom-right }
 		place { control=BroadcastPageMinHoriz	width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
 		place { control=ConsolePage 		width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }

--- a/resource/layout/subpaneloptionsbrowser.layout
+++ b/resource/layout/subpaneloptionsbrowser.layout
@@ -42,7 +42,7 @@
 		place { controls=DescriptionLabel height=40 width=max region=top start=TitleLabel dir=down margin-top=8 }
 		place { controls=OverlayHomePageLabel,OverlayHomePage, dir=down spacing=5 margin-top=20 width=max region=topleft }
 		place { controls=Divider1 region=bottom width=max margin-top=8 }
-		place { controls=ClearAllCookiesButton height=20 width=240 region=bottom start=Divider1 dir=down margin-top=15 }
+		place { controls=ClearAllCookiesButton height=24 width=240 region=bottom start=Divider1 dir=down margin-top=15 }
 		
 	}
 }

--- a/resource/layout/subpaneloptionsingame.layout
+++ b/resource/layout/subpaneloptionsingame.layout
@@ -1,0 +1,86 @@
+"resource/layout/subpaneloptionsingame.layout"
+{
+	controls
+	{
+		TitleLabel { controlname=label labeltext="#Steam_SettingsInGameTitle" style=highlight }
+		EnableOverlayCheck {	ControlName=CheckButton labelText="#Overlay_SettingsEnable" }
+		HotKeySelector {	ControlName=HotKeyEntry	}
+		ScreenshotHotKeySelector { ControlName=HotKeyEntry }
+		DescriptionLabel	{ ControlName=Label labeltext="#Overlay_SettingsDescription" wrap=1  }
+		HotKeySelectorLabel {	ControlName=Label labelText="#Overlay_SettingsHotKeyLabel" }
+		ScreenshotLabel {	ControlName=Label labelText="#Overlay_SettingsScreenshotHotKeyLabel"	}
+		ScreenshotActionLabel 	{	ControlName=Label	labelText="#Overlay_SettingsScreenshotActionLabel" }
+		ScreenshotNotifyCheck { ControlName=CheckButton labelText="#Friends_DisplayNotification" style=checkbox }
+		ScreenshotPlaySoundCheck { ControlName=CheckButton labelText="#Friends_PlayASound" }
+		ScreenshotSaveUncompressedCheck { ControlName=CheckButton labelText="#Overlay_SaveUncompressed" }
+	
+		SetScreenshotFolderButton { ControlName=Button labelText="#Steam_SettingsInGameScreenshotFolder" 	command=SetScreenshotFolder }
+						
+		ShowIngameFPSLabel { ControlName=Label labelText="#Steam_Settings_Ingame_ShowFPS_Title" }
+		ShowIngameFPSCornerCombo { ControlName="ComboBox" fieldName="ShowIngameFPSCombo" editable="0" }
+		ShowIngameFPSContrastCheck { ControlName=CheckButton labelText="#Steam_Settings_Ingame_ShowFPS_HightContrast" style=checkbox }
+	
+		Divider1 { ControlName=Divider	}
+		PingRateLabel {	controlname=label	labeltext=#Steam_ServerBrowserPingRateLabel wrap=1 style=highlight		}
+		PingRateInfo {	controlname=label	labeltext=#Steam_ServerBrowserPingRateInfo wrap=1		}		
+		PingRateCombo
+		{
+			controlname=combobox
+      			editable="0"
+		}		
+	}
+	
+	colors
+	{
+	}	
+	
+	styles
+	{
+		highlight
+		{
+			textcolor=Text
+		}	
+		
+		checkbox
+		{
+			padding-top=0
+			padding-bottom=0
+		}
+	}
+	
+	layout
+	{
+		region { name=box margin-top=10 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
+		region { name=top region=box margin-top=10 }
+		region { name=topleft region=top y=100 width=255 margin-right=20 }
+		region { name=topright region=top x=263 width=235 y=101}
+		
+		region { name=bottom region=box y=320 }
+		
+		place { controls=TitleLabel region=top }
+		place { controls=DescriptionLabel height=40 width=max region=top start=TitleLabel dir=down margin-top=8 }
+		place { controls=EnableOverlayCheck region=top start=DescriptionLabel dir=down height=20 }
+	
+		place { controls=HotKeySelectorLabel,HotKeySelector dir=down spacing=5 width=max region=topleft }
+		
+		place { controls=ShowIngameFPSLabel,ShowIngameFPSCombo,ShowIngameFPSContrastCheck dir=down spacing=5 start=HotKeySelector margin-top=44 width=max region=topleft }
+			
+		place { controls=ScreenshotLabel region=topright }
+		place { controls=ScreenshotHotKeySelector,SetScreenshotFolderButton 
+			dir=down 
+			start=ScreenshotLabel
+			margin-top=4
+			spacing=5
+			width=max
+			height=24
+			region=topright }
+		place { control=ScreenshotActionLabel region=topright start=SetScreenshotFolderButton dir=down margin-top=19 }
+		place { controls=ScreenshotNotifyCheck,ScreenshotPlaySoundCheck,ScreenshotSaveUncompressedCheck dir=down start=ScreenshotActionLabel
+			margin-top=6 margin-left=10 height=22 width=max region=topright }
+		
+		place { control=Divider1 region=bottom width=max }
+		place { controls="PingRateLabel" region=bottom start=Divider1 margin-top=10 width=max dir=down }
+		place { controls="PingRateCombo" region=bottom start=PingRateLabel margin-top=10 width=235 dir=down height=25 }
+		place { controls="PingRateInfo" region=bottom start=PingRateCombo margin-top=10 width=235 dir=down }				
+	}
+}

--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -626,21 +626,6 @@
 			{
 				0="fill( x0, y0, x1, y1, almostblack )" // bg
 			}
-
-			render
-			{
-				0="fill( x0 - 1, y0 + 1, x0 + 1, y1    , DialogBG )"// Left
-
-				// Outer Border
-				1="fill( x0 + 1, y1 - 1, x1 - 0, y1    , ScreenB )"	// Bottom
-				2="fill( x0 + 1, y0 + 1, x0 + 2, y1 - 1, ScreenB4 )"// Left
-				3="fill( x1 - 1, y0 + 1, x1    , y1 - 1, ScreenB )"	// Right
-				
-				// Inner Border
-				4="fill( x0 + 2, y1 - 2, x1 - 1, y1 - 1, Black )"	// Bottom
-				5="fill( x0 + 2, y0 + 2, x0 + 3, y1 - 2, Black )"	// Left
-				6="fill( x1 - 2, y0 + 2, x1 - 1, y1 - 2, Black )"	// Right
-			}
 		}
 		
 		TextEntryURL
@@ -890,7 +875,7 @@
 		place { control=GamesPage_Details 	width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }
 		place { control=GamesPage_Grid 		width=max height=max margin-top=1 margin-left=0 margin-right=9 margin-bottom=20 start=emailreminderbar dir=down }
 		place { control=WebPanel 			width=max height=max margin-top=1 margin-left=1 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }
-		place { control=BroadcastPage			width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }
+		place { control=BroadcastPage			width=max height=max margin-top=3 margin-left=3 margin-right=11 margin-bottom=23 start=emailreminderbar dir=down }
 		place { control=BroadcastPageMin		width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=26 dir=down align=bottom-right }
 		place { control=BroadcastPageMinHoriz	width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
 		place { control=ConsolePage 		width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=emailreminderbar dir=down }


### PR DESCRIPTION
Screenshot Folder button from In-Game settings and Delete All Browser Cookies button from Web Browser settings have been re-sized so their height matches the other buttons.

Realized that I didn't need to add the extra border for the broadcast panel. All I had to do was adjust the margins of the panel so that it fit inside the border that was already provided.
