### PR TITLE
Overlay Web Browser Border Fix

### DIFF
--- a/resource/layout/overlaywebbrowser.layout
+++ b/resource/layout/overlaywebbrowser.layout
@@ -131,7 +131,7 @@
 		
 		HTML
 		{
-			inset="2 2 2 4"
+			inset="2 2 2 2"
 		}
 		
 		"HTML Scrollbar"


### PR DESCRIPTION
The bottom border of the web browser panel in the Steam overlay was two pixels taller than it should have been for some reason. This has now been fixed.
