### PR TITLE
Game Page Subheader BG Fix

### DIFF
--- a/resource/layout/gamespage_details_subheader.layout
+++ b/resource/layout/gamespage_details_subheader.layout
@@ -19,8 +19,8 @@
 		{
 			render_bg
 			{
-				0="fill( x0 + 2, y0 + 2, x1 - 2, y1 - 2, BlackTr )"
-				1="dashedrect( x0 + 2, y0 + 2, x1 - 2, y1 - 2, Black )"
+				0="fill( x0 + 2, y0 + 2, x1 + 2, y1 - 2, BlackTr )"
+				1="dashedrect( x0 + 2, y0 + 2, x1 + 2, y1 - 2, Black )"
 			}
 		}
 		


### PR DESCRIPTION
Increased the length of the games page subheader background (dark rectangle background for play button and session stats) in order to fit pre-order text inside properly.
