### PR TITLE
'Update news' menu option

### DIFF
--- a/resource/menus/Single Menu/steam.menu
+++ b/resource/menus/Single Menu/steam.menu
@@ -51,6 +51,7 @@
 		
 		Divider							{}
 		
+		NewForYou						{	text="#SteamUI_GameProperties_UpdateNews"		shellcmd="steam://open/newforyou" }
 		UserForums						{	text="#steam_forums"					command="Forums" }
 		Support							{	text="#steam_menu_support"				command="Support" }
 		SystemInfo						{	text="#steam_menu_systeminfo"			command="SystemInfo" }

--- a/resource/menus/steam.menu
+++ b/resource/menus/steam.menu
@@ -57,6 +57,8 @@
 		Settings			[!$OSX]		{	text="#steam_menu_settings"				command="Settings" }
 		Divider				[!$OSX]		{}
 		UserForums						{	text="#steam_forums"					command="Forums" }
+		Divider							{}
+		NewForYou						{	text="#SteamUI_GameProperties_UpdateNews"		shellcmd="steam://open/newforyou" }
 	}
 	
 	Profile


### PR DESCRIPTION
Valve recently added an 'Update news' menu option to the 'View' menu: http://store.steampowered.com/news/19185/

While Valve placed the new option right below 'Inventory', I don't feel like it really belongs with that "group" of options, so I've placed it on its own, ala the 'Discussions' option.
