### PR TITLE
Bring "Display download rates in bits per second" checkbox into view

### DIFF
--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -1,0 +1,101 @@
+"resource/layout/subpaneloptionsdownloads.layout"
+{
+	controls
+	{
+		ThrottleRatesLabel { controlname=label	labeltext=#Steam_ThrottleRatesLabel	}
+		RegionLabel {	controlname=label	labeltext=#Steam_RegionLabel	style=highlight 	}
+		LibrariesLabel {	controlname=label	labeltext=#Steam_LibrariesLabel	style=highlight }
+		RestrictionsLabel {	controlname=label	labeltext=#Steam_DownloadRestrictionsLabel	style=highlight 	}
+		RegionInfoLabel {	controlname=label labeltext=#Steam_RegionInfo wrap=1		}
+		ManageInstalledappsLabel { controlname=label labeltext=#SteamUI_ContentMgr_ManageInstalledAppsInfo }
+				
+		ThrottleRates
+		{
+			controlname=combobox
+			editable="0"
+		}	
+		
+		DownloadRegionCombo
+		{
+			controlname=combobox
+			editable="0"
+		}
+		
+		ManageInstalledApps
+		{
+			controlname=button
+			labeltext = #SteamUI_ContentMgr_ManageInstalledApps
+			command=ManageInstalledApps
+		}
+		
+		AutoUpdateTimeRestrictCheckbox { controlname=checkbutton labeltext=#Steam_AutoUpdateTimeRestrictionLabel }
+		AutoUpdateTimeRestrictStartLabel { controlname=label labeltext=#Steam_AutoUpdateTimeRestrictionStart style=padded }
+		AutoUpdateTimeRestrictEndLabel { controlname=label labeltext=#Steam_AutoUpdateTimeRestrictionEnd style=padded }
+		AutoUpdateTimeRestrictStart { controlname=combobox }
+		AutoUpdateTimeRestrictEnd { controlname=combobox }
+		AllowDownloadsDuringGameplayCheckbox { controlname=checkbutton labeltext=#Steam_AllowDownloadsDuringGameplay }
+		AllowDownloadsDuringGameplayInfo { controlname=label labeltext=#Steam_AllowDownloadsDuringGameplayDetails wrap=1 style=padded }
+		ThrottleDownloadsWhileStreamingCheckbox { controlname=checkbutton labeltext=#Steam_ThrottleDownloadsWhileStreaming }
+		ThrottleDownloadsWhileStreamingInfo { controlname=label labeltext=#Steam_ThrottleDownloadsWhileStreamingDetails wrap=1 style=padded }
+		DownloadRatesInBitsCheckbox { controlname=checkbutton labeltext=#Steam_DownloadRatesInBits }
+				
+		Divider1 { ControlName=Divider	}				
+		Divider2 { ControlName=Divider	}				
+		
+	}
+	
+	colors
+	{
+	}	
+	
+	styles
+	{
+		highlight
+		{
+			textcolor=Text
+		}	
+		
+		padded
+		{
+			padding-top=6
+		}
+	}
+	
+	layout
+	{
+		region { name=box margin-top=8 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
+		
+		place { controls="LibrariesLabel" region=box margin-top=8 dir=down }
+		place { controls="ManageInstalledApps" region=box start=LibrariesLabel margin-top=8 width=235 height=25 dir=down }
+		place { controls="ManageInstalledappsLabel" region=box start=ManageInstalledApps margin-top=8 width=max dir=down }		
+		
+		place { controls="Divider1" region=box start=ManageInstalledappsLabel dir=down margin-top=15 width=max }
+		
+		place { controls="RegionLabel" region=box start=Divider1 dir=down margin-top=15 }
+		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=8 height=25 width=235 dir=down }
+		place { controls="RegionInfoLabel" region=box start=DownloadRegionCombo margin-top=8 width=max dir=down }
+	
+		place { controls="Divider2" region=box start=RegionInfoLabel dir=down width=max margin-top=15 }
+				
+		place { controls="RestrictionsLabel" region=box start=Divider2 dir=down margin-top=15 }
+		
+		place { controls="AutoUpdateTimeRestrictCheckbox" region=box start=RestrictionsLabel dir=down margin-top=4 }
+		place { controls="AutoUpdateTimeRestrictStartLabel" region=box start=AutoUpdateTimeRestrictCheckbox dir=down margin-top=4 }
+		place { controls="AutoUpdateTimeRestrictStart" region=box start=AutoUpdateTimeRestrictStartLabel dir=right margin-left=10 width=78 }
+		place { controls="AutoUpdateTimeRestrictEndLabel" region=box start=AutoUpdateTimeRestrictStart dir=right margin-left=20 }
+		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel dir=right margin-left=10 width=78 }
+		
+		place { controls="ThrottleRatesLabel" region=box start=RestrictionsLabel dir=down margin-top=13 margin-left=260 }
+		place { controls="ThrottleRates" region=box start=ThrottleRatesLabel dir=down width=235 height=25 margin-top=8 }
+		
+		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStartLabel dir=down margin-top=8 }
+		place { controls="AllowDownloadsDuringGameplayInfo" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down margin-top=0 width=450 }
+		
+		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayInfo dir=down margin-top=8 }
+		place { controls="ThrottleDownloadsWhileStreamingInfo" region=box start=ThrottleDownloadsWhileStreamingCheckbox dir=down margin-top=0 width=450 }
+		
+		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingInfo dir=down margin-top=8 }
+
+
+	}
+}

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -63,21 +63,21 @@
 	
 	layout
 	{
-		region { name=box margin-top=8 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
+		region { name=box margin-top=10 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
 		
-		place { controls="LibrariesLabel" region=box margin-top=8 dir=down }
-		place { controls="ManageInstalledApps" region=box start=LibrariesLabel margin-top=8 width=235 height=25 dir=down }
-		place { controls="ManageInstalledappsLabel" region=box start=ManageInstalledApps margin-top=8 width=max dir=down }		
+		place { controls="LibrariesLabel" region=box margin-top=10 dir=down }
+		place { controls="ManageInstalledApps" region=box start=LibrariesLabel margin-top=10 width=235 height=25 dir=down }
+		place { controls="ManageInstalledappsLabel" region=box start=ManageInstalledApps margin-top=10 width=max dir=down }		
 		
-		place { controls="Divider1" region=box start=ManageInstalledappsLabel dir=down margin-top=15 width=max }
+		place { controls="Divider1" region=box start=ManageInstalledappsLabel dir=down margin-top=10 width=max }
 		
-		place { controls="RegionLabel" region=box start=Divider1 dir=down margin-top=15 }
-		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=8 height=25 width=235 dir=down }
-		place { controls="RegionInfoLabel" region=box start=DownloadRegionCombo margin-top=8 width=max dir=down }
+		place { controls="RegionLabel" region=box start=Divider1 dir=down margin-top=10 }
+		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=10 height=25 width=235 dir=down }
+		place { controls="RegionInfoLabel" region=box start=DownloadRegionCombo margin-top=10 width=max dir=down }
 	
-		place { controls="Divider2" region=box start=RegionInfoLabel dir=down width=max margin-top=15 }
+		place { controls="Divider2" region=box start=RegionInfoLabel dir=down width=max margin-top=10 }
 				
-		place { controls="RestrictionsLabel" region=box start=Divider2 dir=down margin-top=15 }
+		place { controls="RestrictionsLabel" region=box start=Divider2 dir=down margin-top=10 }
 		
 		place { controls="AutoUpdateTimeRestrictCheckbox" region=box start=RestrictionsLabel dir=down margin-top=4 }
 		place { controls="AutoUpdateTimeRestrictStartLabel" region=box start=AutoUpdateTimeRestrictCheckbox dir=down margin-top=4 }
@@ -86,15 +86,15 @@
 		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel dir=right margin-left=10 width=78 }
 		
 		place { controls="ThrottleRatesLabel" region=box start=RestrictionsLabel dir=down margin-top=13 margin-left=260 }
-		place { controls="ThrottleRates" region=box start=ThrottleRatesLabel dir=down width=235 height=25 margin-top=8 }
+		place { controls="ThrottleRates" region=box start=ThrottleRatesLabel dir=down width=235 height=25 margin-top=10 }
 		
-		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStartLabel dir=down margin-top=8 }
+		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStartLabel dir=down margin-top=10 }
 		place { controls="AllowDownloadsDuringGameplayInfo" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down margin-top=0 width=450 }
 		
-		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayInfo dir=down margin-top=8 }
+		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayInfo dir=down margin-top=10 }
 		place { controls="ThrottleDownloadsWhileStreamingInfo" region=box start=ThrottleDownloadsWhileStreamingCheckbox dir=down margin-top=0 width=450 }
 		
-		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingInfo dir=down margin-top=8 }
+		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingInfo dir=down margin-top=10 }
 
 
 	}


### PR DESCRIPTION
Valve recently added "an option to display download speeds as bits per second (Mbps) instead of MB/sec, for easier comparison with the way network and internet connection speeds are traditionally reported":
http://store.steampowered.com/news/20748/

This new option is currently hidden in Pixelvision2 due to the default margin-top values in Steam's resource/layout/subpaneloptionsdownloads.layout file. This pull request adds the subpaneloptionsdownloads.layout file to Pixelvision2 so that we can override the margin-top values in order to get the new option to show up. I modified the divider-related margin-top values from "15" to "10" as compared to Steam's file.
