### PR TITLE
Fixed alignment in settings in steam beta Aug 23 2016

### DIFF
--- a/resource/layout/subpaneloptionsbrowser.layout
+++ b/resource/layout/subpaneloptionsbrowser.layout
@@ -42,7 +42,8 @@
 		place { controls=DescriptionLabel height=40 width=max region=top start=TitleLabel dir=down margin-top=8 }
 		place { controls=OverlayHomePageLabel,OverlayHomePage, dir=down spacing=5 margin-top=20 width=max region=topleft }
 		place { controls=Divider1 region=bottom width=max margin-top=8 }
-		place { controls=ClearAllCookiesButton height=24 width=240 region=bottom start=Divider1 dir=down margin-top=15 }
+		place { controls=ClearWebCacheButton height=24 width=240 region=bottom start=Divider1 dir=down margin-top=15 }
+		place { controls=ClearAllCookiesButton height=24 width=240 region=bottom start=ClearWebCacheButton dir=down margin-top=15 }
 		
 	}
 }

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -91,11 +91,15 @@
 		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStartLabel dir=down margin-top=10 }
 		place { controls="AllowDownloadsDuringGameplayInfo" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down margin-top=0 width=450 }
 
-		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayInfo dir=down margin-top=10 }
+		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down margin-top=10 }
 		place { controls="ThrottleDownloadsWhileStreamingInfo" region=box start=ThrottleDownloadsWhileStreamingCheckbox dir=down margin-top=0 width=450 }
 
-		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingInfo dir=down margin-top=10 }
+		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingCheckbox dir=down margin-top=10 }
 
-
+		place { controls="Divider3" region=box start=DownloadRatesInBitsCheckbox dir=down width=max margin-top=10 }
+		
+		place { controls="FlushDownloadConfig" region=box start=Divider3 margin-top=15 width=235 height=25 dir=down }
+		place { controls="FlushDownloadConfigLabel" region=box start=FlushDownloadConfig margin-top=10 width=max dir=down }
+		
 	}
 }


### PR DESCRIPTION
Fixed the alignment for the new settings introduced in the steam beta, bringing the settings window up to date to the steam beta build Aug 23 2016, 11:28:44.

These include:
- The download cache options in the Downloads tab
- The web browser cache option in the Web Browser tab
