### PR TITLE
Small patch to fix text wrapping in game properties -> Updates

### DIFF
--- a/resource/layout/gameproperties_updates.layout
+++ b/resource/layout/gameproperties_updates.layout
@@ -1,0 +1,143 @@
+"resource/layout/gameproperties_updates.layout"
+{
+	controls
+	{
+	
+		UpdateCombo
+		{
+			"ControlName"		"ComboBox"
+		}
+		
+		UpdateNewsURL
+		{
+			"ControlName"		"URLLabel"
+			"fieldName"		"UpdateNewsURL"
+			"labelText"		"#Steam_Game_UpdateNewsURL"
+			"textAlignment"		"north-west"
+			"wrap"		"0"
+			"URLText"		"http://www.steampowered.com/platform/update_history/Day of Defeat Source.html"
+		}
+		
+		UpdateInfoText
+		{
+			"ControlName"		"Label"
+			"fieldName"		"UpdateInfoText"
+			"wide"		"328"
+			"tall"		"42"
+			"labelText"		"#Steam_GameProperties_NeverUpdateInfo"
+			"textAlignment"		"north-west"
+			"wrap"		"1"
+		}
+		
+		AutoUpdatesLabel
+		{
+			"ControlName"		"Label"
+			"labelText"		"#Steam_Automatic_Updates"
+			"textAlignment"		"west"
+			//"associate"		"UpdateCombo"
+			"wrap"		"0"
+			"style"	"Highlight"
+		}
+		
+		BackgroundDownloadsLabel { controlname=label labeltext="#Steam_GameProperties_BackgroundDownloadsWhilePlaying" style="Highlight" }
+		BackgroundDownloadsInfo { controlname=label labeltext="#Steam_GameProperties_BackgroundDownloadsWhilePlayingInfo" wrap=1 }
+		BackgroundDownloadsCombo { controlname=combobox }
+		
+		Divider1
+		{
+			"ControlName"		"Divider"
+		}
+		
+		Divider2
+		{
+			"ControlName"		"Divider"
+		}
+				
+		CloudLabel
+		{
+			"ControlName"		"Label"
+			"labelText"		"#Steam_CloudLabel"
+			"textAlignment"		"west"
+			"style"	"Highlight"
+		}
+		
+		CloudInfoLabel
+		{
+			"ControlName"		"Label"
+			"labelText"		"#Steam_CloudInfo"
+			"textAlignment"		"north-west"
+			"wrap"		"1"
+		}	
+		
+		EnableCloudCheck
+		{
+			"ControlName"		"CheckButton"
+			"labelText"		"#Steam_EnableCloudForApp"
+			"textAlignment"		"west"
+		}
+		
+		CloudUsageLabel
+		{
+			"ControlName"		"Label"
+			"wide"		"418"
+			"tall"		"28"
+			"labelText"		"#Steam_CloudUsage"
+			"textAlignment"		"west"
+			"wrap"		"1"
+			"style"	"CloudUsageLabelStyle"
+		}	
+	
+		CloudEnableLinkLabel
+		{
+			"ControlName"	"URLLabel"
+			"labelText"		"#Steam_CloudEnableLink"
+			"URLText"		"steam://settings/downloads"
+			"tall"			"28"
+		}
+		
+		CloudEnableLinkLabelExtraText
+		{
+			"controlname"	"Label"
+			"Labeltext"		"#Steam_CloudEnableLinkContinued"
+			"tall"			"28"
+		}
+	}
+	
+	styles
+	{
+		Highlight
+		{
+			textcolor=text
+		}
+		
+		CloudUsageLabelStyle:disabled
+		{
+			textcolor=TextDisabled
+		}
+	}
+	
+	layout
+	{
+		region { name=main margin=20 }
+		
+		place { controls="AutoUpdatesLabel" region=main }
+		place { controls="UpdateCombo" region=main start=AutoUpdatesLabel dir=down width=334 height=24 margin-top=12 }
+		place { controls="UpdateInfoText" region=main start=UpdateCombo dir=down width=470 height=42 margin-top=6 }
+		place { controls="UpdateNewsURL" region=main start=UpdateInfoText dir=down width=418 height=28 margin-top=6 }
+		
+		place { controls="Divider1" region=main start=UpdateNewsURL dir=down width=max margin-top=26 }
+		
+		place { controls="BackgroundDownloadsLabel" region=main start=Divider1 dir=down width=334 margin-top=8 }
+		place { controls="BackgroundDownloadsInfo" region=main start=BackgroundDownloadsLabel dir=down width=470 margin-top=12 }
+		place { controls="BackgroundDownloadsCombo" region=main start=BackgroundDownloadsInfo dir=down width=334 height=24 margin-top=8 }
+		
+		place { controls="Divider2" region=main start=BackgroundDownloadsCombo dir=down width=max margin-top=26 }
+		
+		place { controls="CloudLabel" region=main start=Divider2 dir=down width=450 margin-top=8 }
+		place { controls="CloudInfoLabel" region=main start=CloudLabel dir=down width=470 margin-top=12 }
+		place { controls="EnableCloudCheck" region=main start=CloudInfoLabel dir=down width=420 height=28 margin-top=2 }
+		place { controls="CloudUsageLabel" region=main start=EnableCloudCheck dir=down width=420 height=28 margin-top=0 margin-left=28 }
+		place { controls="CloudEnableLinkLabel" region=main start=CloudUsageLabel height=28 dir=down spacing=4 wrap=1 margin-top=0 margin-left=-28 }
+		place { controls="CloudEnableLinkLabelExtraText" region=main start=CloudEnableLinkLabel height=28 dir=right margin-left=4 wrap=1 margin-top=0 }
+	}
+}


### PR DESCRIPTION
Some of the info boxes in properties -> updates were too small in width so the whole text info couldn't be seen. A very minor tweak.