### PR TITLE
Update to fix misaligned chevron

### DIFF
--- a/resource/styles/tweaks/fs_largest.styles
+++ b/resource/styles/tweaks/fs_largest.styles
@@ -313,7 +313,7 @@
 		
 		MenuButton
 		{
-			font-size=18
+			font-size=17
 		}
 		
 		MenuItem


### PR DESCRIPTION
Misalignment happens when using +4 font size in the tweaks.ini file.  Anything above size 17 (in the MenuButton) seems to cause misalignment.