### PR TITLE
Pop-Up Shake Fix

### DIFF
--- a/Overrides/Smaller Big Picture icon/resource/layout/uinavigatorpanel.layout
+++ b/Overrides/Smaller Big Picture icon/resource/layout/uinavigatorpanel.layout
@@ -866,7 +866,7 @@
 		
 		place { control="PageLoadThrobber" align=right y=58 height=20 width=20 margin-right=10 margin-top=1 }
 		
-		place { control="subnavgroup_library" align=left y=57 height=24 width=max margin-right=8 margin-left=8 }
+		place { control="subnavgroup_library" align=top-center y=57 height=24 width=max margin-right=8 margin-left=8 }
 		
 		place { control="refresh,stop,URLStatusImage,EVCert,URLBar" align=left y=59 height=20 width=max spacing=4 margin-left=9 margin-right=30 }
 		
@@ -904,7 +904,7 @@
 		place { control=BroadcastPageMinHoriz	width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
 		place { control=ConsolePage 		width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=phonereminderbar dir=down }
 		
-		place { control=NewLibraryPage	width=max height=max margin-top=3 margin-left=-4 margin-right=4 margin-bottom=23 start=subnavgroup_library dir=down }
+		place { control=NewLibraryPage	width=max height=max margin-top=-27 margin-left=-4 margin-right=4 margin-bottom=23 start=phonereminderbar dir=down }
 
 		place { control=MediaPage 			width=max height=max margin-top=1 margin-left=0 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
 		place { control=ToolsPage 			width=max height=max margin-top=1 margin-left=0 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }

--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -866,7 +866,7 @@
 		
 		place { control="PageLoadThrobber" align=right y=58 height=20 width=20 margin-right=10 margin-top=1 }
 		
-		place { control="subnavgroup_library" align=left y=57 height=24 width=max margin-right=8 margin-left=8 }
+		place { control="subnavgroup_library" align=top-center y=57 height=24 width=max margin-right=8 margin-left=8 }
 		
 		place { control="refresh,stop,URLStatusImage,EVCert,URLBar" align=left y=59 height=20 width=max spacing=4 margin-left=9 margin-right=30 }
 		
@@ -904,7 +904,7 @@
 		place { control=BroadcastPageMinHoriz	width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
 		place { control=ConsolePage 		width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=phonereminderbar dir=down }
 		
-		place { control=NewLibraryPage	width=max height=max margin-top=3 margin-left=-4 margin-right=4 margin-bottom=23 start=subnavgroup_library dir=down }
+		place { control=NewLibraryPage	width=max height=max margin-top=-27 margin-left=-4 margin-right=4 margin-bottom=23 start=phonereminderbar dir=down }
 
 		place { control=MediaPage 			width=max height=max margin-top=1 margin-left=0 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
 		place { control=ToolsPage 			width=max height=max margin-top=1 margin-left=0 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }


### PR DESCRIPTION
Attempting fix for a pop-up issue in Steam's webpages mentioned in the group discussions.

Issue mentioned here: https://steamcommunity.com/groups/pixelvision2/discussions/0/1631916406851123934/

The issue seems to appear when the resolution scaling is set to be higher than 100%, or from observation I believe it does, however the issue has only been tested with 125% scaling, unsure if the issue exists below this.

Note: Must enable Steam's scaling option in order to trigger the issue.