### PR TITLE
Various Locales' Navigation Icons Repositioned

### DIFF
--- a/locale.ini
+++ b/locale.ini
@@ -7,7 +7,7 @@ locale.ini
 //	!! -- READ THESE INSTRUCTIONS CAREFULLY -- !!
 //
 //    PixelVision is setup by default for the use of Steam in English. If you are using Steam in another
-//    language, you'll have to specify which language in order for the skin to properly adapt. To do so,
+//    language, you will have to specify which language in order for the skin to properly adapt. To do so,
 //    follow these instructions carefully:
 //
 //	1. Find your language in the list below, for example:	   // Russian

--- a/resource/styles/tweaks/locale/bulgarian.styles
+++ b/resource/styles/tweaks/locale/bulgarian.styles
@@ -20,9 +20,9 @@
 				
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
-				7="image( x0 + 223, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
+				7="image( x0 + 218, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 390, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 533, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 538, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/czech.styles
+++ b/resource/styles/tweaks/locale/czech.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 216, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 357, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 502, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 507, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/danish.styles
+++ b/resource/styles/tweaks/locale/danish.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 189, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 326, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 481, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 323, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 486, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/default_english.styles
+++ b/resource/styles/tweaks/locale/default_english.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 192, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 312, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 474, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 477, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 

--- a/resource/styles/tweaks/locale/dutch.styles
+++ b/resource/styles/tweaks/locale/dutch.styles
@@ -20,9 +20,9 @@
 				
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
-				7="image( x0 + 205, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 325, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 487, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				7="image( x0 + 190, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
+				8="image( x0 + 335, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 500, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/finnish.styles
+++ b/resource/styles/tweaks/locale/finnish.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 212, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 360, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 484, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 340, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 469, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/french.styles
+++ b/resource/styles/tweaks/locale/french.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 220, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 391, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 571, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 576, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/german.styles
+++ b/resource/styles/tweaks/locale/german.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 191, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 339, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 501, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 503, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/greek.styles
+++ b/resource/styles/tweaks/locale/greek.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 259, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 404, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 573, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 407, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 582, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/hungarian.styles
+++ b/resource/styles/tweaks/locale/hungarian.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 207, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 345, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 487, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 493, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/korean.styles
+++ b/resource/styles/tweaks/locale/korean.styles
@@ -20,9 +20,9 @@
 				
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
-				7="image( x0 + 188, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 352, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 495, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				7="image( x0 + 186, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
+				8="image( x0 + 347, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 492, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/norwegian.styles
+++ b/resource/styles/tweaks/locale/norwegian.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 199, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 336, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 473, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 478, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/polish.styles
+++ b/resource/styles/tweaks/locale/polish.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 193, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 339, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 508, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 513, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/portuguese.styles
+++ b/resource/styles/tweaks/locale/portuguese.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 181, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 327, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 499, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 330, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 503, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/portuguese_brazil.styles
+++ b/resource/styles/tweaks/locale/portuguese_brazil.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 181, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 327, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 499, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 330, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 503, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/romanian.styles
+++ b/resource/styles/tweaks/locale/romanian.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 219, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 351, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 513, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 366, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 531, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/russian.styles
+++ b/resource/styles/tweaks/locale/russian.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 223, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 390, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 563, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 393, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 571, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/spanish.styles
+++ b/resource/styles/tweaks/locale/spanish.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 204, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 350, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 512, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 353, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 515, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/swedish.styles
+++ b/resource/styles/tweaks/locale/swedish.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 189, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 326, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 489, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 492, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/thai.styles
+++ b/resource/styles/tweaks/locale/thai.styles
@@ -20,9 +20,9 @@
 				
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
-				7="image( x0 + 201, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
+				7="image( x0 + 198, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 294, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 407, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 405, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/turkish.styles
+++ b/resource/styles/tweaks/locale/turkish.styles
@@ -22,7 +22,7 @@
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 214, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
 				8="image( x0 + 370, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 505, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				9="image( x0 + 508, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}

--- a/resource/styles/tweaks/locale/ukrainian.styles
+++ b/resource/styles/tweaks/locale/ukrainian.styles
@@ -21,8 +21,8 @@
 				// Navigation Icons
 				6="image( x0 + 84 , y0 + 49, x1, y1, graphics/nav_icon_store )"		// Store
 				7="image( x0 + 238, y0 + 48, x1, y1, graphics/nav_icon_library )"	// Library
-				8="image( x0 + 390, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
-				9="image( x0 + 544, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
+				8="image( x0 + 395, y0 + 48, x1, y1, graphics/nav_icon_community )"	// Community
+				9="image( x0 + 551, y0 + 48, x1, y1, graphics/nav_icon_news )"		// User
 			}
 		}
 	}


### PR DESCRIPTION
Updated Locales in this PR's update are:
- Bulgarian
- Czech
- Danish
- Dutch
- English
- Finnish
- French
- German
- Greek
- Hungarian
- Korean
- Norwegian
- Polish
- Portuguese
- Romanian
- Russian
- Spanish
- Swedish
- Thai
- Turkish
- Ukrainian