### PR TITLE
Controller Settings

### DIFF
--- a/resource/layout/subpaneloptionscontroller.layout
+++ b/resource/layout/subpaneloptionscontroller.layout
@@ -1,0 +1,56 @@
+"resource/layout/subpaneloptionscontroller.layout"
+{
+	controls
+	{
+		TitleLabel { controlname=label labeltext="#Steam_SettingsControllerTitle" style=highlight }
+		DescriptionLabel	{ ControlName=Label labeltext="#Steam_SettingsControllerDescription" wrap=1  }
+		Divider1 { ControlName=Divider	}
+		DescriptionBindingLabel	{ ControlName=Label labeltext="#Steam_SettingsControllerBindingDescription" wrap=1  }
+	
+		GeneralSettingsButton { ControlName=Button labelText="#Steam_SettingsControllerGeneralSettings" 	command=EditGeneralSettings }
+		BigPictureConfigButton { ControlName=Button labelText="#Steam_SettingsControllerBigPictureConfig" 	command=EditBPConfig }		
+		DesktopConfigButton { ControlName=Button labelText="#Steam_SettingsControllerDesktopConfig" 	command=EditDesktopConfig }
+		GuideConfigButton { ControlName=Button labelText="#Steam_SettingsControllerGuideConfig" 	command=EditGuideConfig }				
+		Divider2 { ControlName=Divider	}
+		DisableNotificationsCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableNotifications"}
+	}
+	
+	colors
+	{
+	}	
+	
+	styles
+	{
+		highlight
+		{
+			textcolor=Text
+		}	
+		
+		checkbox
+		{
+			padding-top=0
+			padding-bottom=0
+		}
+	}
+	
+	layout
+	{
+		region { name=box margin-top=10 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
+		region { name=top region=box margin-top=10 }
+		region { name=topleft region=top y=130 width=255 margin-right=20 }
+		region { name=topright region=top x=263 width=235 y=131}
+		
+		region { name=bottom region=box y=320 }
+		
+		place { controls=TitleLabel margin-top=20 margin-left=20 margin-right=20 width=max }
+		place { start=TitleLabel controls=DescriptionLabel height=40 region=top dir=down margin-top=15 width=max }		
+		place { start=DescriptionLabel controls=GeneralSettingsButton height=20 width=240 region=top dir=down margin-top=15 }
+		place { start=GeneralSettingsButton controls=Divider1 height=20 region=top dir=down width=max }		
+		place { start=Divider1 controls=DescriptionBindingLabel height=40 region=top dir=down margin-top=15 width=max }			
+		place { start=DescriptionBindingLabel controls=BigPictureConfigButton height=20 width=240 region=top dir=down margin-top=15 }	
+		place { start=BigPictureConfigButton controls=DesktopConfigButton height=20 width=240 region=top dir=down margin-top=15 }			
+		place { start=DesktopConfigButton controls=GuideConfigButton height=20 width=240 region=top dir=down margin-top=15 }								
+		place { start=GuideConfigButton controls=Divider2 height=20 region=top dir=down width=max}		
+		place { start=Divider2 controls=DisableNotificationsCheckbox height=20 width=max region=top dir=down margin-top=15 }
+	}
+}

--- a/resource/layout/subpaneloptionscontroller.layout
+++ b/resource/layout/subpaneloptionscontroller.layout
@@ -3,16 +3,20 @@
 	controls
 	{
 		TitleLabel { controlname=label labeltext="#Steam_SettingsControllerTitle" style=highlight }
-		DescriptionLabel	{ ControlName=Label labeltext="#Steam_SettingsControllerDescription" wrap=1  }
-		Divider1 { ControlName=Divider	}
-		DescriptionBindingLabel	{ ControlName=Label labeltext="#Steam_SettingsControllerBindingDescription" wrap=1  }
+		DescriptionLabel { ControlName=Label labeltext="#Steam_SettingsControllerDescription" wrap=1 }
 	
-		GeneralSettingsButton { ControlName=Button labelText="#Steam_SettingsControllerGeneralSettings" 	command=EditGeneralSettings }
-		BigPictureConfigButton { ControlName=Button labelText="#Steam_SettingsControllerBigPictureConfig" 	command=EditBPConfig }		
-		DesktopConfigButton { ControlName=Button labelText="#Steam_SettingsControllerDesktopConfig" 	command=EditDesktopConfig }
-		GuideConfigButton { ControlName=Button labelText="#Steam_SettingsControllerGuideConfig" 	command=EditGuideConfig }				
-		Divider2 { ControlName=Divider	}
-		DisableNotificationsCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableNotifications"}
+		GeneralSettingsButton { ControlName=Button labelText="#Steam_SettingsControllerGeneralSettings" command=EditGeneralSettings }
+		
+		Divider1 { ControlName=Divider }
+
+		DescriptionBindingLabel	{ ControlName=Label labeltext="#Steam_SettingsControllerBindingDescription" wrap=1 }
+		BigPictureConfigButton { ControlName=Button labelText="#Steam_SettingsControllerBigPictureConfig" command=EditBPConfig }		
+		DesktopConfigButton { ControlName=Button labelText="#Steam_SettingsControllerDesktopConfig" command=EditDesktopConfig }
+		GuideConfigButton { ControlName=Button labelText="#Steam_SettingsControllerGuideConfig" command=EditGuideConfig }				
+		
+		Divider2 { ControlName=Divider }
+
+		DisableNotificationsCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableNotifications" }
 	}
 	
 	colors
@@ -43,14 +47,18 @@
 		region { name=bottom region=box y=320 }
 		
 		place { controls=TitleLabel margin-top=20 margin-left=20 margin-right=20 width=max }
-		place { start=TitleLabel controls=DescriptionLabel height=40 region=top dir=down margin-top=15 width=max }		
-		place { start=DescriptionLabel controls=GeneralSettingsButton height=20 width=240 region=top dir=down margin-top=15 }
-		place { start=GeneralSettingsButton controls=Divider1 height=20 region=top dir=down width=max }		
-		place { start=Divider1 controls=DescriptionBindingLabel height=40 region=top dir=down margin-top=15 width=max }			
-		place { start=DescriptionBindingLabel controls=BigPictureConfigButton height=20 width=240 region=top dir=down margin-top=15 }	
-		place { start=BigPictureConfigButton controls=DesktopConfigButton height=20 width=240 region=top dir=down margin-top=15 }			
-		place { start=DesktopConfigButton controls=GuideConfigButton height=20 width=240 region=top dir=down margin-top=15 }								
-		place { start=GuideConfigButton controls=Divider2 height=20 region=top dir=down width=max}		
-		place { start=Divider2 controls=DisableNotificationsCheckbox height=20 width=max region=top dir=down margin-top=15 }
+		place { controls=DescriptionLabel start=TitleLabel height=40 region=top dir=down margin-top=15 width=max }		
+		place { controls=GeneralSettingsButton start=DescriptionLabel height=24 width=300 region=top dir=down margin-top=15 }
+		
+		place { controls=Divider1 start=GeneralSettingsButton height=20 region=top dir=down width=max }		
+		
+		place { controls=DescriptionBindingLabel start=Divider1 height=40 region=top dir=down margin-top=15 width=max }			
+		place { controls=BigPictureConfigButton start=DescriptionBindingLabel height=24 width=300 region=top dir=down margin-top=15 }	
+		place { controls=DesktopConfigButton start=BigPictureConfigButton height=24 width=300 region=top dir=down margin-top=15 }			
+		place { controls=GuideConfigButton start=DesktopConfigButton height=24 width=300 region=top dir=down margin-top=15 }								
+		
+		place { controls=Divider2 start=GuideConfigButton height=20 region=top dir=down width=max}		
+		
+		place { controls=DisableNotificationsCheckbox start=Divider2 height=20 width=max region=top dir=down margin-top=15 }
 	}
 }


### PR DESCRIPTION
This wasn't in the skin before, but I've added it in from Steam's own default layout and adjusted the button widths and height to make it more consistent with the rest of the setting pages.

Decided to increase the width of the buttons as an issue of the button's box being a little too small in German locale, and there was enough room to extend the buttons.

[Here's the example](https://i.imgur.com/eRZmxxG.png) which came from [this discussion thread on Steam](https://steamcommunity.com/groups/pixelvision2/discussions/0/2295094308087983384/)

The issues listed here were mentioned in the above mentioned Steam discussion.