### PR TITLE
Cover URL Bar in Library View

### DIFF
--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -912,7 +912,7 @@
 		place { control=BroadcastPageMinHoriz		width=300 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
 		place { control=ConsolePage					width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=phonereminderbar dir=down }
 
-		place { control=NewLibraryPage				width=max height=max margin-top=31 margin-left=3 margin-right=11 margin-bottom=23 start=subnavgroup_library dir=down }
+		place { control=NewLibraryPage				width=max height=max margin-top=0 margin-left=1 margin-right=9 margin-bottom=21 start=subnavgroup_library dir=down }
 
 		place { control=MediaPage 					width=max height=max margin-top=1 margin-left=0 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
 		place { control=ToolsPage 					width=max height=max margin-top=1 margin-left=0 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }


### PR DESCRIPTION
The URL bar is unused in the current library, so I've readjusted the Library View again to cover it up.

I also covered the web browser/viewport borders, this fits more into PV2's original design versus what I originally coded for the Library.